### PR TITLE
Complete driver-list favorite part

### DIFF
--- a/client/src/components/DefaultView/DriverView.jsx
+++ b/client/src/components/DefaultView/DriverView.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import Autocomplete from "react-google-autocomplete";
 import { Link } from 'react-router-dom';
 import { MdLogout } from 'react-icons/md';
-import { HiOutlineRefresh } from 'react-icons/hi';
+import { TbRefresh } from "react-icons/tb";
 import DefaultRoute from './DefaultRoute.jsx';
 import DriverPrompt from './DriverPromptModal.jsx';
 import { format } from "date-fns";
@@ -127,7 +127,7 @@ function DriverView ({ userId }) {
         <div className="headerToggleView">
           <Link to="/riderview">
             <div className="viewToggle">Rider</div>
-            <HiOutlineRefresh className="viewToggleButton" size={25} />
+            <TbRefresh className="viewToggleButton" size={25} />
           </Link>
         </div>
         <div className="headerAvatarLogout">

--- a/client/src/components/DefaultView/RiderView.jsx
+++ b/client/src/components/DefaultView/RiderView.jsx
@@ -23,6 +23,7 @@ function RiderView ({ userId }) {
   })
   const [name, setName] = useState('');
   const [avatar, setAvatar] = useState('');
+  const [userInfo, setUserInfo] = useState({})
   const [displayTime, setDisplayTime] = useState(new Date());
   const [time, setTime] = useState('');
   const [isDefault, setIsDefault] = useState(false);
@@ -47,6 +48,7 @@ function RiderView ({ userId }) {
     .then((result) => {
       setAvatar(result.data[0].avatar)
       setName(result.data[0].full_name)
+      setUserInfo(result.data[0])
       setUpcoming(result.data[0].rider_route)
     })
     .catch(err => console.log(err))
@@ -132,7 +134,7 @@ function RiderView ({ userId }) {
               </div>
             </div>
 
-            <Link to="/driver-list" state={{route: route}}>
+            <Link to="/driver-list" state={{route: route, userInfo: userInfo}}>
               <button className="primary-btn-find">Find Drivers</button>
             </Link>
           </div>

--- a/client/src/components/DriverList/DriverCard.jsx
+++ b/client/src/components/DriverList/DriverCard.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom'
 import axios from 'axios';
 import { FiInfo } from "react-icons/fi";
 import { HiOutlineHeart, HiHeart } from "react-icons/hi";
@@ -6,7 +7,7 @@ import { HiOutlineHeart, HiHeart } from "react-icons/hi";
 import DriverConfirmation from './DriverConfirmation.jsx'
 import BookingSuccessMessage from './BookingSuccessMessage.jsx'
 
-const DriverCard = ({driverInfo, userRouteInfo, startDistance, endDistance, updateRiderOnGoingRoute}) => {
+const DriverCard = ({driverInfo, userInfo, userRouteInfo, startDistance, endDistance, updateRiderOnGoingRoute}) => {
 
   const [driverConfirmationOn, setDriverConfirmation] = useState(false);
   const [successMessageOn, setSuccessMessage] = useState(false);
@@ -19,7 +20,7 @@ const DriverCard = ({driverInfo, userRouteInfo, startDistance, endDistance, upda
     setSuccessMessage(!successMessageOn)
   }
 
-  const [favoriteDriver, setFavoriteDriver] = useState((driverInfo.favorites || []).includes(driverInfo._id))
+  const [favoriteDriver, setFavoriteDriver] = useState((userInfo.favorites || []).includes(driverInfo._id))
 
   const toggleFavoriteDriver = () => {
     if (favoriteDriver) {
@@ -72,7 +73,9 @@ const DriverCard = ({driverInfo, userRouteInfo, startDistance, endDistance, upda
               ? <HiHeart className='card-icon full-heart-icon' onClick={() => {toggleFavoriteDriver()}}/>
               : <HiOutlineHeart className='card-icon outlined-heart-icon' onClick={() => {toggleFavoriteDriver()}}/>
             }
-            <FiInfo className='card-icon info-icon'/>
+            <Link to="/ratings-reviews" state={{userData: userInfo, revieweeData: driverInfo, from: 'driver-list'}}>
+              <FiInfo className='card-icon info-icon'/>
+            </Link>
           </div>
         </div>
         <p>From: {startDistance.text} from your starting point</p>

--- a/client/src/components/DriverList/DriverList.jsx
+++ b/client/src/components/DriverList/DriverList.jsx
@@ -1,7 +1,13 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 import './driver-list-style.css'
 import { useLocation } from 'react-router-dom'
+
+import { BiArrowBack } from 'react-icons/bi';
+import { TbRefresh } from "react-icons/tb";
+import { MdLogout } from 'react-icons/md';
+
 
 import DriverCard from './DriverCard.jsx'
 
@@ -11,7 +17,7 @@ const DriverList = (props) => {
   const [userRouteInfo, setUserRouteInfo] = useState({})
 
   const info = useLocation()
-  const {route} = info.state
+  const {route, userInfo} = info.state
 
   const findDrivers = () => {
     const rider = {
@@ -38,7 +44,7 @@ const DriverList = (props) => {
     setUserRouteInfo(rider);
     return axios.post('/driver-list', rider)
       .then((res) => {
-        console.log(res.data)
+        console.log('Driver list: ', res.data)
         return setDrivers(res.data);
       })
       .catch((err) => console.log('Find drivers error: ', err))
@@ -49,14 +55,60 @@ const DriverList = (props) => {
 
 
   if (drivers.length > 0) {
+    const favoritesDrivers = [];
+    const nonFavoritesDrivers = [];
+    for (let i = 0; i < drivers.length; i++) {
+      if ((userInfo.favorites || []).includes(drivers[i].driverInfo._id)) {
+        favoritesDrivers.push(drivers[i])
+      } else {
+        nonFavoritesDrivers.push(drivers[i])
+      }
+    }
     return (
       <div>
-        <div className='top-bar'></div>
+        <div className='top-bar'>
+          <div className='top-bar-left'>
+            <p>Rider</p>
+            <Link to="/driverview">
+              <TbRefresh className='top-bar-icons' />
+            </Link>
+          </div>
+          <div className='top-bar-right'>
+            <Link to="/riderprofile">
+              <img className='avatar' src={userInfo.avatar} alt="" />
+            </Link>
+            <Link to="/">
+              <MdLogout className='top-bar-icons' />
+            </Link>
+          </div>
+        </div>
+        <div className='title-bar'>
+          <Link to="/riderview">
+            <BiArrowBack className='driver-list-back-icon' />
+          </Link>
+          <p>Your nearest drivers</p>
+        </div>
         <div className='driver-list'>
-          {drivers.map((driver) => (
+          <p className='subheader-driver'>Favorite drivers</p>
+          {favoritesDrivers.map((driver) => (
             <DriverCard
               key={driver.driverInfo._id}
               driverInfo={driver.driverInfo}
+              userInfo={userInfo}
+              userRouteInfo={userRouteInfo}
+              startDistance={driver.startDistance}
+              endDistance={driver.endDistance}
+              updateRiderOnGoingRoute={props.updateRiderOnGoingRoute}
+            />
+          ))}
+        </div>
+        <div className='driver-list'>
+          <p className='subheader-driver'>Non-favorite drivers</p>
+          {nonFavoritesDrivers.map((driver) => (
+            <DriverCard
+              key={driver.driverInfo._id}
+              driverInfo={driver.driverInfo}
+              userInfo={userInfo}
               userRouteInfo={userRouteInfo}
               startDistance={driver.startDistance}
               endDistance={driver.endDistance}

--- a/client/src/components/DriverList/driver-list-style.css
+++ b/client/src/components/DriverList/driver-list-style.css
@@ -1,3 +1,19 @@
+.title-bar {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 16px 40px 16px 16px;
+}
+
+.title-bar p {
+  margin: 0;
+  flex-grow: 1;
+  text-align: center;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--gray6);
+}
+
 .driver-list {
   max-width: 400px;
   width: 100%;
@@ -11,6 +27,13 @@
 
 .driver-list p {
   margin: 0;
+}
+
+.subheader-driver {
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--gray4);
+  width: 100%;
 }
 
 .card p {
@@ -57,6 +80,36 @@
   align-items: center;
   font-size: 18px;
   font-weight: 600;
+}
+
+/* ------------- Top bar --------------------------- */
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+}
+
+.top-bar-left {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 16px;
+}
+
+.top-bar-left p {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--green3);
+}
+
+.top-bar-right {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 24px;
 }
 
 /* ------------- Buttons --------------------------- */
@@ -236,4 +289,14 @@
   gap: 16px;
   justify-content: flex-end;
   align-items: center;
+}
+
+.driver-list-back-icon {
+  font-size: 24px;
+  color: var(--gray6);
+}
+
+.top-bar-icons {
+  font-size: 24px;
+  color: var(--gray6);
 }

--- a/client/src/components/DriverList/driver-list-style.css
+++ b/client/src/components/DriverList/driver-list-style.css
@@ -17,8 +17,6 @@
   margin: 0
 }
 
-div
-
 .card {
   width: 100%;
   display: flex;
@@ -71,7 +69,6 @@ div
   font-size: 16px;
   font-weight: 500;
   padding: 10px 20px;
-  width: 100%;
 }
 
 .primary-btn:hover {

--- a/client/src/components/RiderList/RiderList.jsx
+++ b/client/src/components/RiderList/RiderList.jsx
@@ -91,21 +91,21 @@ const RiderList = function(props) {
             )
           })}
         </div>
-      <div className="rider-card-list">
-        {riders.map((rider) => {
-          return (
-            <div className="rider-card" key={rider.rider.email}>
-              <button className="info-icon" type="submit">insert info icon here</button>
-              <div className="rider-name">{rider.rider.full_name}</div>
-              {/* <div><img alt="specific user profile" className="rider-pic" src={rider.pic} /></div> */}
-              <div className="rider-from">{rider.startDistance.text} Miles from Your Pick-Up Location</div>
-              <div className="rider-to">{rider.endDistance.text} Miles to go from Drop-Off Location</div>
-              {/* <div className="rider-time">{rider.time}</div> */}
-              <button className="remove-rider" name={rider.rider.email} onClick={removeRider} type="submit">decline this rider</button>
-            </div>
-          )
-        })}
-
+        <div className="rider-card-list">
+          {riders.map((rider) => {
+            return (
+              <div className="rider-card" key={rider.rider.email}>
+                <button className="info-icon" type="submit">insert info icon here</button>
+                <div className="rider-name">{rider.rider.full_name}</div>
+                {/* <div><img alt="specific user profile" className="rider-pic" src={rider.pic} /></div> */}
+                <div className="rider-from">{rider.startDistance.text} Miles from Your Pick-Up Location</div>
+                <div className="rider-to">{rider.endDistance.text} Miles to go from Drop-Off Location</div>
+                {/* <div className="rider-time">{rider.time}</div> */}
+                <button className="remove-rider" name={rider.rider.email} onClick={removeRider} type="submit">decline this rider</button>
+              </div>
+            )
+          })}
+        </div>
       </div>
     )
   }

--- a/client/src/components/UserProfile/DriverProfile.jsx
+++ b/client/src/components/UserProfile/DriverProfile.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { Link } from 'react-router-dom';
 import { AiFillHome } from 'react-icons/ai';
 import { MdLogout } from 'react-icons/md';
-import { HiOutlineRefresh } from 'react-icons/hi';
+import { TbRefresh } from "react-icons/tb";
 import { FaPen, FaCheckCircle} from 'react-icons/fa';
 import DriverReviewsList from './DriverReviewsList.jsx';
 import Ratings from 'react-ratings-declarative';
@@ -102,7 +102,7 @@ class DriverProfile extends React.Component {
       <div>
       {/* TOP BUTTONS */}
         <span className='profileToggle'>Driver</span>
-        <span className='profileToggleButton'><HiOutlineRefresh/></span>
+        <span className='profileToggleButton'><TbRefresh/></span>
         <Link to="/"><span className='profileLogoutButton'><MdLogout /></span></Link>
         <Link to="/driverview"><span className='profileHomeButton'><AiFillHome/></span></Link>
 

--- a/database/models/user.js
+++ b/database/models/user.js
@@ -14,7 +14,10 @@ const userSchema = mongoose.Schema({
   drivers_license:  String,
   license_plate:    String,
   dob:              String,
-  avatar:           String,
+  avatar: {
+    type: String,
+    default: 'https://i.pinimg.com/474x/f1/da/a7/f1daa70c9e3343cebd66ac2342d5be3f.jpg'
+  },
   is_driver:        Boolean,
   is_rider:         Boolean,
 


### PR DESCRIPTION
I've completed:
- Separate my driver list into 2 parts: favorite drivers and non-favorite drivers, cards sorted based on the distance between driver and rider's starting point in ascending order as @romanlaughs has suggested
- Allow to navigate to driver-review page of @bbissing 
- Allow to go back to rider view
- Allow to navigate to rider profile
- Allow to logout from driver-list
- Allow to switch to driver view
- Edit the avatar value in schema to take default value as a default picture, then we're not worry about user being queried without avatar value and may cause rendering errors.

My driver-list view:

![Screen Shot 2023-02-04 at 1 30 27 AM](https://user-images.githubusercontent.com/103070104/216759889-d9c80ddc-2caf-4d26-9c61-ebb18a017483.jpg)
