### PR TITLE
Refactor styles of ongoing upcoming card, refactor function when decline rider and cancel rider_route

### DIFF
--- a/client/dist/style.css
+++ b/client/dist/style.css
@@ -20,14 +20,20 @@
   font-family: 'Poppins', 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
 }
 
+html, body {
+  height: 100%;
+}
+
 body {
   display: flex;
   justify-content: center;
-  align-items: flex-start;
+  align-items: stretch;
+  background-color: var(--gray1);
 }
 
 #root {
   max-width: 375px;
+  flex-grow: 1;
 }
 
 /* body {

--- a/client/dist/style.css
+++ b/client/dist/style.css
@@ -29,11 +29,13 @@ body {
   justify-content: center;
   align-items: stretch;
   background-color: var(--gray1);
+  font-family: 'Poppins', 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
 }
 
 #root {
   max-width: 375px;
   flex-grow: 1;
+  background-color: var(--gray1);
 }
 
 /* body {
@@ -64,6 +66,7 @@ h1 {
   padding: 0px;
   position: relative;
   width: 375px;
+  font-family: 'Poppins';
 }
 
 .defaultViewHeader {
@@ -360,11 +363,14 @@ h1 {
   order: 2;
   align-self: stretch;
   flex-grow: 0;
+  font-size: 16px;
+  font-weight: 400;
+  text-transform: capitalize;
 }
 
 .primary-btn-find:disabled {
   background: var(--gray3);
-  color: var(--gray1);
+  color: var(--gray6);
 }
 
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -94,7 +94,7 @@ function App() {
           <Route path="/driverprofile" element={<DriverProfile  />} />
           <Route path="/riderprofile" element={<RiderProfile logOut={logOut}/>} />
           <Route path="/driver-list" element={<DriverList updateRiderOnGoingRoute={updateRiderOnGoingRoute} logOut={logOut}/>} />
-          <Route path="/rider-list" element={<DriverInteractions updateRiderOnGoingRoute={updateRiderOnGoingRoute}/>} />
+          <Route path="/rider-list" element={<DriverInteractions updateRiderOnGoingRoute={updateRiderOnGoingRoute} logOut={logOut}/>} />
           <Route path="/trip-complete-rider" element={<TripCompleteRider />} />
           <Route path="/trip-complete-driver" element={<TripCompleteDriver />} />
         </Route>

--- a/client/src/components/DefaultView/DriverView.jsx
+++ b/client/src/components/DefaultView/DriverView.jsx
@@ -221,7 +221,7 @@ function DriverView ({ userId, logOut }) {
         </div>
         <div className='top-bar-right'>
           <Link to="/driverprofile" state={{id: userId, userInfo: userInfo, from: 'driverview'}}>
-            <img className='headerAvatar' src={avatar} alt="avatar-small" />
+            <img className='avatar' src={avatar} alt="avatar-small" />
           </Link>
           <Link to="/">
             <RiLogoutBoxRLine className='top-bar-icons' onClick={logOut}/>

--- a/client/src/components/DefaultView/OngoingTripDriver.jsx
+++ b/client/src/components/DefaultView/OngoingTripDriver.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'
+import { HiArrowNarrowRight } from 'react-icons/hi';
 import axios from 'axios';
 import './ongoing-trip-style.css';
 
@@ -30,24 +31,29 @@ const OngoingTripDriver = (props) => {
         <h5>Ongoing Trip</h5>
         <div className="card">
           <div className="card-header-driver">
-            {user.driver_route.riders.length === 0
-              ? (<div className="no-riders"> Ride Alone</div>)
-              : (
-                <ul className='avatars'>
-                  {user.driver_route.riders.map(rider => {
-                    return (
-                    <Link to="/ratings-reviews" state={ {from: 'driverview', userData: user, revieweeData: rider.rider_id, view: 'driver'} } key={rider.rider_id._id}>
-                      <li className="avatars__item">
-                        <img src={rider.rider_id.avatar} alt="avatar" className='avatars__img'/>
-                      </li>
-                    </Link>
-                    )
-                  })}
-                </ul>
-              )
+            <div className='card-header-driver-left'>
+              {user.driver_route.riders.length === 0
+                ? (<div className="no-riders">Ride Alone</div>)
+                : (
+                  <ul className='avatars'>
+                    {user.driver_route.riders.map(rider => {
+                      return (
+                        <li className="avatar-li" key={rider.rider_id._id}>
+                          <Link to="/ratings-reviews" state={ {from: 'driverview', userData: user, revieweeData: rider.rider_id, view: 'driver'} }>
+                            <img src={rider.rider_id.avatar} alt="avatar" className='avatar avatar-item'/>
+                          </Link>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                )
               }
-            <div>
+            </div>
+            <div className='card-header-driver-right'>
               <p className="trip-capacity">{user.driver_route.riders.length} / {user.driver_route.total_seats}</p>
+              <Link to="/rider-list" state={{dir: props.passedMapData, route: props.passedRoute, userInfo: props.passedUserInfo}}>
+                <HiArrowNarrowRight className='driver-list-forward-icon' />
+              </Link>
             </div>
           </div>
           <div className="trip-card-body">

--- a/client/src/components/DefaultView/RiderView.jsx
+++ b/client/src/components/DefaultView/RiderView.jsx
@@ -138,7 +138,7 @@ function RiderView ({ userId, riderOnGoingRoute, logOut }) {
         </div>
         <div className='top-bar-right'>
           <Link to="/riderprofile" state={{id: userId, userInfo: userInfo, from: 'riderview'}}>
-            <img className='headerAvatar' src={avatar} alt="avatar-small" />
+            <img className='avatar' src={avatar} alt="avatar-small" />
           </Link>
           <Link to="/">
             <RiLogoutBoxRLine className='top-bar-icons' onClick={logOut}/>

--- a/client/src/components/DefaultView/UpcomingTripDriver.jsx
+++ b/client/src/components/DefaultView/UpcomingTripDriver.jsx
@@ -41,7 +41,7 @@ const UpcomingTripDriver = (props) => {
                   return (
                   <Link to="/ratings-reviews" state={ {from: 'driverview', userData: user, revieweeData: rider.rider_id, view: 'driver'} } key={rider.rider_id._id}>
                     <li className="avatars__item">
-                      <img src={rider.rider_id.avatar} alt="avatar" className='avatars__img'/>
+                      <img src={rider.rider_id.avatar} alt="avatar" className='avatar'/>
                     </li>
                   </Link>
                   )

--- a/client/src/components/DefaultView/UpcomingTripDriver.jsx
+++ b/client/src/components/DefaultView/UpcomingTripDriver.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'
-import { IoMdArrowRoundForward } from 'react-icons/io';
+import { HiArrowNarrowRight } from 'react-icons/hi';
 import axios from 'axios';
 import './ongoing-trip-style.css';
 
@@ -33,28 +33,29 @@ const UpcomingTripDriver = (props) => {
         <h5>Upcoming Trip</h5>
         <div className="card">
           <div className="card-header-driver">
-            {user.driver_route.riders.length === 0
-            ? (<div className="no-riders"> No Riders Yet :(</div>)
-            : (
-              <ul className='avatars'>
-                {user.driver_route.riders.map(rider => {
-                  return (
-                  <Link to="/ratings-reviews" state={ {from: 'driverview', userData: user, revieweeData: rider.rider_id, view: 'driver'} } key={rider.rider_id._id}>
-                    <li className="avatars__item">
-                      <img src={rider.rider_id.avatar} alt="avatar" className='avatar'/>
-                    </li>
-                  </Link>
-                  )
-                })}
-              </ul>
-            )
-            }
-            <div>
-              <p className="trip-capacity">{user.driver_route.riders.length} / {user.driver_route.total_seats}</p>
+            <div className='card-header-driver-left'>
+              {user.driver_route.riders.length === 0
+                ? (<div className="no-riders"> No Riders Yet</div>)
+                : (
+                  <ul className='avatars'>
+                    {user.driver_route.riders.map(rider => {
+                      return (
+                        <li className="avatar-li" key={rider.rider_id._id}>
+                          <Link to="/ratings-reviews" state={ {from: 'driverview', userData: user, revieweeData: rider.rider_id, view: 'driver'} }>
+                            <img src={rider.rider_id.avatar} alt="avatar" className='avatar avatar-item'/>
+                          </Link>
+                        </li>
+
+                      )
+                    })}
+                  </ul>
+                )
+              }
             </div>
-            <div>
+            <div className='card-header-driver-right'>
+              <p className="trip-capacity">{user.driver_route.riders.length} / {user.driver_route.total_seats}</p>
               <Link to="/rider-list" state={{dir: props.passedMapData, route: props.passedRoute, userInfo: props.passedUserInfo}}>
-                <IoMdArrowRoundForward className='driver-list-forward-icon' />
+                <HiArrowNarrowRight className='driver-list-forward-icon' />
               </Link>
             </div>
           </div>

--- a/client/src/components/DefaultView/ongoing-trip-style.css
+++ b/client/src/components/DefaultView/ongoing-trip-style.css
@@ -109,76 +109,41 @@
 
 /* COOL AVATAR OVERLAP */
 
-ul.avatars {
-  display: flex ; /* Causes LI items to display in row. */
+.card-header-driver-left {
+  display: flex;
+  align-items: center;
+  min-height: 40px;
+  width: 80%;
+}
+
+.card-header-driver-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px
+}
+
+.avatars {
+  margin: 0;
+  padding: 0 0 0 4px;
   list-style-type: none ;
-  /* margin: auto ; Centers vertically / horizontally in flex container. */
-  /* padding: 0px 85px 0px 0px ; */
-  z-index: 1 ; /* Sets up new stack-container. */
+  flex-grow: 1;
+  display: flex ;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 4px 0;
 }
 
-li.avatars__item {
-  height: 49px ;
-  margin: 0px 0px 0px 0px ;
-  padding: 0px 0px 0px 0px ;
-  position: relative ;
-  width: 42px ; /* Forces flex items to be smaller than their contents. */
+.avatar-li {
+  box-sizing: border-box;
+  margin: 0 -4px;
+  border-radius: 50px;
+  border: 2px solid var(--gray1);
 }
 
-/*
-  These zIndex values will only be relative to the contents of the UL element,
-  which sets up its own stack container. As such, these will only be relevant
-  to each other, not to the page at large.
-  --
-  NOTE: We could theoretically get around having to set explicit zIndex values
-  by using "flex-direction: row-reverse" and using the natural stacking order
-  of the DOM; however, to do that, we'd have to reverse the order of the HTML
-  elements, which feels janky and unnatural.
-*/
-li.avatars__item:nth-child( 1 ) { z-index: 9 ; }
-li.avatars__item:nth-child( 2 ) { z-index: 8 ; }
-li.avatars__item:nth-child( 3 ) { z-index: 7 ; }
-li.avatars__item:nth-child( 4 ) { z-index: 6 ; }
-li.avatars__item:nth-child( 5 ) { z-index: 5 ; }
-li.avatars__item:nth-child( 6 ) { z-index: 4 ; }
-li.avatars__item:nth-child( 7 ) { z-index: 3 ; }
-li.avatars__item:nth-child( 8 ) { z-index: 2 ; }
-li.avatars__item:nth-child( 9 ) { z-index: 1 ; }
-
-/*
-  These items are all 49px wide while the flex-item (in which they live) is
-  only 42px wide. As such, there will be several pixels of overflow content,
-  which will be displayed in a reverse-stacking order based on above zIndex.
-*/
-img.avatars__img,
-span.avatars__initials,
-span.avatars__others {
-  background-color: #596376 ;
-  border-radius: 100px 100px 100px 100px ;
-  color: #FFFFFF ;
-  display: block ;
-  font-family: sans-serif ;
-  font-size: 12px ;
-  font-weight: 100 ;
-  height: 45px ;
-  line-height: 45px ;
-  text-align: center ;
-  width: 45px ;
-}
-
-span.avatars__others {
-  background-color: #1E8FE1 ;
-}
-
-/* COOL AVATAR OVERLAP END */
-
-.trip-capacity {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 18px;
-  color: var(--gray4);
+.driver-list-forward-icon {
+  font-size: 24px;
 }
 
 .title-margin {

--- a/client/src/components/DriverList/driver-list-style.css
+++ b/client/src/components/DriverList/driver-list-style.css
@@ -198,8 +198,8 @@
 }
 
 .avatar {
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   border-radius: 100px;
   object-fit: cover;
 }

--- a/client/src/components/DriverList/driver-list-style.css
+++ b/client/src/components/DriverList/driver-list-style.css
@@ -175,6 +175,10 @@
   margin: 0
 }
 
+.card p {
+  margin: 0;
+}
+
 .subheader-driver {
   margin: 0;
   flex-grow: 1;
@@ -321,7 +325,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  border: 1px solid var(--gray4);
+  border: 1px solid var(--gray3);
   border-radius: 5px;
   padding: 16px 16px;
   margin: 0

--- a/client/src/components/RiderList/DriverInteractions.jsx
+++ b/client/src/components/RiderList/DriverInteractions.jsx
@@ -16,7 +16,7 @@ const containerStyle = {
   width: '343px',
   height: '275px',
   borderRadius: '10px',
-  border: '1px solid var(--green2)'
+  border: '1px solid var(--gray4)'
 };
 
 const center = {

--- a/database/controllers/defaultviews.js
+++ b/database/controllers/defaultviews.js
@@ -61,17 +61,24 @@ module.exports = {
     return User.findOneAndUpdate(id, update).then((result) => console.log('Updated user record with license info')).catch(err => console.log('Error updating user record'));
   },
 
-  addIdToRiderListOfDriver: (driverId, newRiderId, startDistance, endDistance) => {
+  addIdToRiderListOfDriver: async (driverId, newRiderId, startDistance, endDistance) => {
     const driver_id = {_id: driverId};
     const rider = {
       rider_id: newRiderId,
       starting_distance: startDistance,
       end_distance: endDistance
     }
-    User.updateOne(driver_id, {$push: {"driver_route.riders": rider}})
-      .then (() => console.log('Successfully added rider id to driver\'s rider list '))
-      .catch((err) => {
-        console.log('Error adding rider id to driver\'s rider list: ', err)})
+    try {
+      const driver = await User.findOne(driver_id)
+      if (!driver.driver_route.riders.includes(newRiderId)) {
+        await User.updateOne(driver_id, {$push: {"driver_route.riders": rider}})
+        console.log('Successfully added rider id to driver\'s rider list ')
+      } else {
+        console.log('This rider is already in the list')
+      }
+    } catch(err) {
+      console.log('Error adding rider id to driver\'s rider list: ', err)
+    }
   },
 
   removeIdOffRiderListOfDriver: (driverId, riderId) => {

--- a/database/controllers/tripComplete.js
+++ b/database/controllers/tripComplete.js
@@ -75,13 +75,15 @@ module.exports = {
   },
 
   // cancel rider route
-  cancelRiderRoute: async (_id) => {
-    let users = await User.find({ _id })
-    let user = users[0];
+  cancelRiderRoute: async (rider_id, driver_id) => {
+    if (driver_id === undefined) {
+      let user = await User.findOne({_id: rider_id});
+      driver_id = user.rider_route.driver_id
+    }
     // remove rider from riders array of driver
-    await User.updateOne({_id: user.rider_route.driver_id}, {$pull: {"driver_route.riders.rider_id": _id}}).catch(err => console.log(err));
+    await User.updateOne({_id: driver_id}, {$pull: {"driver_route.riders": {rider_id: rider_id}}}).catch(err => console.log(err));
     // remove rider_route for user
-    await User.updateOne({_id }, {$set: {rider_route: { started: false }}}).catch(err => console.log(err));
+    await User.updateOne({_id: rider_id }, {$set: {rider_route: { started: false }}}).catch(err => console.log(err));
     return 'Successfully cancelled route'
   },
 

--- a/database/controllers/tripComplete.js
+++ b/database/controllers/tripComplete.js
@@ -79,7 +79,7 @@ module.exports = {
     let users = await User.find({ _id })
     let user = users[0];
     // remove rider from riders array of driver
-    await User.updateOne({_id: user.rider_route.driver_id }, {$pull: {driver_route: {riders: _id}}}).catch(err => console.log(err));
+    await User.updateOne({_id: user.rider_route.driver_id}, {$pull: {"driver_route.riders.rider_id": _id}}).catch(err => console.log(err));
     // remove rider_route for user
     await User.updateOne({_id }, {$set: {rider_route: { started: false }}}).catch(err => console.log(err));
     return 'Successfully cancelled route'

--- a/server/index.js
+++ b/server/index.js
@@ -359,7 +359,8 @@ app.post("/rider-remove", async (req, res) => {
     const driverID = req.body.driverID;
     const riderID = req.body.riderID;
       try {
-        const removedRiders = await removeRiderFromRiderArray(driverID, riderID);
+        // This will both get rider's id off driver_route.riders list and reset rider's rider_route
+        const removedRiders = await tripComplete.cancelRiderRoute(riderID, driverID);
         res.status(200).send(removedRiders);
       }
       catch (err) {


### PR DESCRIPTION
- Restyle the ongoing/upcoming cards
- Refactor the `cancelRiderRoute` function in controllers so that it could be used for both cases when the driver declines a rider and when a rider cancels the trip, both actions do the same tasks: remove rider's id off the `driver_route.riders` array, and reset `rider_route` of the rider back to `rider_route: {started: false}`