### PR TITLE
changed webpack configurations - test

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,9 @@ const path = require('path');
 
 const isProduction = process.env.NODE_ENV === 'production';
 const TerserPlugin = require('terser-webpack-plugin');
-const Dotenv = require('dotenv-webpack');
+const webpack = require('webpack');
+require('dotenv').config({ path: './.env' });
+// const Dotenv = require('dotenv-webpack');
 
 const stylesHandler = 'style-loader';
 
@@ -25,7 +27,10 @@ const config = {
     },
 
     plugins: [
-      new Dotenv()
+    //   new Dotenv()
+    new webpack.DefinePlugin({
+        "process.env": JSON.stringify(process.env),
+      }),
     ],
 
     module: {


### PR DESCRIPTION
made edits to webpack. this seemed to help with our deployed version rendering the map properly as well as unsplash and anything that utilized process.env on the client side. default route still acts up. i believe this has something to do with local storage. i'll explain more at the meeting.